### PR TITLE
Deprecating RemoteTenantManagerService in favor of TenantMgtAdminService

### DIFF
--- a/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
+++ b/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.um.ws.service;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.AbstractAdmin;
+import org.wso2.carbon.um.ws.service.internal.UMRemoteServicesDSComponent;
+import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.tenant.Tenant;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
@@ -28,75 +28,92 @@ import org.wso2.carbon.user.core.tenant.TenantManager;
 @Deprecated
 public class TenantManagerService extends AbstractAdmin {
 
-    private static Log log = LogFactory.getLog(TenantManager.class);
-
-    private static final String logMessage =
-            "RemoteTenantManagerService is deprecated. Please use TenantMgtAdminService for tenant related operations";
-
-    public void activateTenant(int tenantId) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public void activateTenant(int tenantId) throws UserStoreException {
+        try {
+            getTenantManager().activateTenant(tenantId);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public int addTenant(Tenant tenant) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public int addTenant(Tenant tenant) throws UserStoreException {
+        try {
+            return getTenantManager().addTenant(tenant);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public void deactivateTenant(int tenantId) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public void deactivateTenant(int tenantId) throws UserStoreException {
+        try {
+            getTenantManager().deactivateTenant(tenantId);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public void deleteTenant(int tenantId) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public void deleteTenant(int tenantId) throws UserStoreException {
+        try {
+            getTenantManager().deleteTenant(tenantId);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public Tenant[] getAllTenants() {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public Tenant[] getAllTenants() throws UserStoreException {
+        try {
+            return (Tenant[]) getTenantManager().getAllTenants();
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public String getDomain(int tenantId) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public String getDomain(int tenantId) throws UserStoreException {
+        try {
+            return getTenantManager().getDomain(tenantId);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public String getSuperTenantDomain() {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public String getSuperTenantDomain() throws UserStoreException {
+        return getTenantManager().getSuperTenantDomain();
     }
 
-    public Tenant getTenant(int tenantId) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public Tenant getTenant(int tenantId) throws UserStoreException {
+        try {
+            return (Tenant) getTenantManager().getTenant(tenantId);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public int getTenantId(String domain) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public int getTenantId(String domain) throws UserStoreException {
+        try {
+            return getTenantManager().getTenantId(domain);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public boolean isTenantActive(int tenantId) {
-
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    public boolean isTenantActive(int tenantId) throws UserStoreException {
+        try {
+            return getTenantManager().isTenantActive(tenantId);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
     }
 
-    public void updateTenant(Tenant tenant) {
+    public void updateTenant(Tenant tenant) throws UserStoreException {
+        try {
+            getTenantManager().updateTenant(tenant);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException(e);
+        }
+    }
 
-        log.error(logMessage);
-        throw new RuntimeException(logMessage);
+    private TenantManager getTenantManager() {
+        return UMRemoteServicesDSComponent.getRealmService().getTenantManager();
     }
 
 }

--- a/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
+++ b/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
@@ -18,101 +18,84 @@
 
 package org.wso2.carbon.um.ws.service;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.AbstractAdmin;
-import org.wso2.carbon.um.ws.service.internal.UMRemoteServicesDSComponent;
-import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.tenant.Tenant;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
 // TODO super tenant service
 public class TenantManagerService extends AbstractAdmin {
 
-    public void activateTenant(int tenantId) throws UserStoreException {
-        try {
-            getTenantManager().activateTenant(tenantId);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    private static Log log = LogFactory.getLog(TenantManager.class);
+
+    private static final String logMessage =
+            "RemoteTenantManagerService is deprecated. Please use TenantMgtAdminService for tenant related operations";
+
+    public void activateTenant(int tenantId) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public int addTenant(Tenant tenant) throws UserStoreException {
-        try {
-            return getTenantManager().addTenant(tenant);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public int addTenant(Tenant tenant) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public void deactivateTenant(int tenantId) throws UserStoreException {
-        try {
-            getTenantManager().deactivateTenant(tenantId);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public void deactivateTenant(int tenantId) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public void deleteTenant(int tenantId) throws UserStoreException {
-        try {
-            getTenantManager().deleteTenant(tenantId);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public void deleteTenant(int tenantId) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public Tenant[] getAllTenants() throws UserStoreException {
-        try {
-            return (Tenant[]) getTenantManager().getAllTenants();
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public Tenant[] getAllTenants() {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public String getDomain(int tenantId) throws UserStoreException {
-        try {
-            return getTenantManager().getDomain(tenantId);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public String getDomain(int tenantId) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public String getSuperTenantDomain() throws UserStoreException {
-        return getTenantManager().getSuperTenantDomain();
+    public String getSuperTenantDomain() {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public Tenant getTenant(int tenantId) throws UserStoreException {
-        try {
-            return (Tenant) getTenantManager().getTenant(tenantId);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public Tenant getTenant(int tenantId) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public int getTenantId(String domain) throws UserStoreException {
-        try {
-            return getTenantManager().getTenantId(domain);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public int getTenantId(String domain) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public boolean isTenantActive(int tenantId) throws UserStoreException {
-        try {
-            return getTenantManager().isTenantActive(tenantId);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
+    public boolean isTenantActive(int tenantId) {
+
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
-    public void updateTenant(Tenant tenant) throws UserStoreException {
-        try {
-            getTenantManager().updateTenant(tenant);
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException(e);
-        }
-    }
+    public void updateTenant(Tenant tenant) {
 
-    private TenantManager getTenantManager() {
-        return UMRemoteServicesDSComponent.getRealmService().getTenantManager();
+        log.error(logMessage);
+        throw new RuntimeException(logMessage);
     }
 
 }

--- a/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
+++ b/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.user.core.tenant.Tenant;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
 // TODO super tenant service
+@Deprecated
 public class TenantManagerService extends AbstractAdmin {
 
     private static Log log = LogFactory.getLog(TenantManager.class);

--- a/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
+++ b/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.um.ws.service;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.core.AbstractAdmin;
 import org.wso2.carbon.um.ws.service.internal.UMRemoteServicesDSComponent;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -28,7 +30,15 @@ import org.wso2.carbon.user.core.tenant.TenantManager;
 @Deprecated
 public class TenantManagerService extends AbstractAdmin {
 
+    private static Log log = LogFactory.getLog(TenantManager.class);
+
+    private static final String logMessage =
+            "RemoteTenantManagerService is deprecated. Please use TenantMgtAdminService for tenant related operations";
+
     public void activateTenant(int tenantId) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             getTenantManager().activateTenant(tenantId);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -37,6 +47,9 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public int addTenant(Tenant tenant) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             return getTenantManager().addTenant(tenant);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -45,6 +58,9 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public void deactivateTenant(int tenantId) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             getTenantManager().deactivateTenant(tenantId);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -53,6 +69,9 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public void deleteTenant(int tenantId) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             getTenantManager().deleteTenant(tenantId);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -61,6 +80,9 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public Tenant[] getAllTenants() throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             return (Tenant[]) getTenantManager().getAllTenants();
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -69,6 +91,7 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public String getDomain(int tenantId) throws UserStoreException {
+
         try {
             return getTenantManager().getDomain(tenantId);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -77,10 +100,16 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public String getSuperTenantDomain() throws UserStoreException {
+
+        log.warn(logMessage);
+
         return getTenantManager().getSuperTenantDomain();
     }
 
     public Tenant getTenant(int tenantId) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             return (Tenant) getTenantManager().getTenant(tenantId);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -89,6 +118,9 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public int getTenantId(String domain) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             return getTenantManager().getTenantId(domain);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -97,6 +129,9 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public boolean isTenantActive(int tenantId) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             return getTenantManager().isTenantActive(tenantId);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -105,6 +140,9 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     public void updateTenant(Tenant tenant) throws UserStoreException {
+
+        log.warn(logMessage);
+
         try {
             getTenantManager().updateTenant(tenant);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
@@ -113,6 +151,7 @@ public class TenantManagerService extends AbstractAdmin {
     }
 
     private TenantManager getTenantManager() {
+
         return UMRemoteServicesDSComponent.getRealmService().getTenantManager();
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

There are several occasions where RemoteTenantManagerService was referred and used for tenant related configurations. For example, some suggestions use this for tenant deletion which WSO2 does not recommend. There is also full-fledged  TenantMgtAdminService which is used for proper management of tenants. 

This PR deprecates RemoteTenantManagerService in favor of TenantMgtAdminService.


### When should this PR be merged

There are no specific dependencies so can be merged once reviewed.