### PR TITLE
Remove deprecated annotation from Axis2 service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.iws
 *.ipr
 .idea
+.DS_Store
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
+++ b/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/TenantManagerService.java
@@ -26,8 +26,10 @@ import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.tenant.Tenant;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
-// TODO super tenant service
-@Deprecated
+/**
+ * RemoteTenantManagerService admin service.
+ * @deprecated as of version 5.3.5. Use {@link org.wso2.carbon.tenant.mgt.services.TenantMgtAdminService}
+ */
 public class TenantManagerService extends AbstractAdmin {
 
     private static Log log = LogFactory.getLog(TenantManager.class);
@@ -154,5 +156,4 @@ public class TenantManagerService extends AbstractAdmin {
 
         return UMRemoteServicesDSComponent.getRealmService().getTenantManager();
     }
-
 }


### PR DESCRIPTION
When `@Deprecated` annotation is added to the service level, Axis2 will try to find javax.ws.rs.Produces class which is not available in the Identity Server runtime, resulting in a ClassNotFoundException. Hence removing the `@Deprecated` annotation and indicating the deprecation from the doc comment.