### PR TITLE
Add two-way operations to RemoteUserStoreManagerService

### DIFF
--- a/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/UserStoreManagerService.java
+++ b/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/UserStoreManagerService.java
@@ -61,14 +61,14 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Adds a new user.
      *
-     * @param userName              the username of the user
-     * @param credential            the credential/password of the user
-     * @param roleList              the roles to be assigned to the user
-     * @param claims                the properties of the user
-     * @param profileName           the profile name for the user
-     * @param requirePasswordChange whether to require a password change
-     * @return                      true if the operation completes successfully
-     * @throws UserStoreException   if an error occurs during the operation
+     * @param userName              The username of the user.
+     * @param credential            The credential/password of the user.
+     * @param roleList              The roles to be assigned to the user.
+     * @param claims                The properties of the user.
+     * @param profileName           The profile name for the user.
+     * @param requirePasswordChange Whether to require a password change.
+     * @return                      True if the operation completes successfully.
+     * @throws UserStoreException   If an error occurs during the operation.
      */
     public boolean addUserV2(String userName, String credential, String[] roleList, ClaimValue[] claims,
                              String profileName, boolean requirePasswordChange) throws UserStoreException {
@@ -87,11 +87,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Sets multiple user claim values.
      *
-     * @param userName             the username of the user
-     * @param claims               the claims to be set
-     * @param profileName          the profile name of the user
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param claims               The claims to be set.
+     * @param profileName          The profile name of the user.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean setUserClaimValuesV2(String userName, ClaimValue[] claims, String profileName)
             throws UserStoreException {
@@ -149,11 +149,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Adds multiple user claim values.
      *
-     * @param userName             the username of the user
-     * @param claims               the claims to be added
-     * @param profileName          the profile name of the user
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param claims               The claims to be added.
+     * @param profileName          The profile name of the user.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean addUserClaimValuesV2(String userName, ClaimValue[] claims, String profileName)
             throws UserStoreException {
@@ -180,11 +180,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Adds a new role.
      *
-     * @param roleName             the name of the role to be added
-     * @param userList             the users to be assigned the added role
-     * @param permissions          the permissions of the role
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param roleName             The name of the role to be added.
+     * @param userList             The users to be assigned the added role.
+     * @param permissions          The permissions of the role.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean addRoleV2(String roleName, String[] userList, PermissionDTO[] permissions)
             throws UserStoreException {
@@ -212,11 +212,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Updates a user's credential/password.
      *
-     * @param userName             the username of the user
-     * @param newCredential        the new credential to be set
-     * @param oldCredential        the old credential to be changed
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param newCredential        The new credential to be set.
+     * @param oldCredential        The old credential to be changed.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean updateCredentialV2(String userName, String newCredential, String oldCredential)
             throws UserStoreException {
@@ -233,10 +233,10 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Updates a user's credential/password as an admin.
      *
-     * @param userName             the username of the user
-     * @param newCredential        the new credential to be set
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param newCredential        The new credential to be set.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean updateCredentialByAdminV2(String userName, String newCredential)
             throws UserStoreException {
@@ -261,9 +261,9 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Deletes a role.
      *
-     * @param roleName             the name of the role to be deleted
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param roleName             The name of the role to be deleted.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean deleteRoleV2(String roleName) throws UserStoreException {
 
@@ -279,9 +279,9 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Deletes a user.
      *
-     * @param userName             the name of the user to be deleted
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The name of the user to be deleted.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean deleteUserV2(String userName) throws UserStoreException {
 
@@ -298,11 +298,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Deletes a single user claim value.
      *
-     * @param userName             the username of the user
-     * @param claimURI             the name of the claim
-     * @param profileName          the profile name of the user
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param claimURI             The name of the claim.
+     * @param profileName          The profile name of the user.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean deleteUserClaimValueV2(String userName, String claimURI, String profileName)
             throws UserStoreException {
@@ -320,11 +320,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Deletes multiple user claim values.
      *
-     * @param userName             the username of the user
-     * @param claims               the names of the claims
-     * @param profileName          the profile name of the user
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param claims               The names of the claims.
+     * @param profileName          The profile name of the user.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean deleteUserClaimValuesV2(String userName, String[] claims, String profileName)
             throws UserStoreException {
@@ -417,12 +417,12 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Sets a single user claim value.
      *
-     * @param userName             the username of the user
-     * @param claimURI             the name of the claim to be set
-     * @param claimValue           the claim value to be set
-     * @param profileName          the profile name of the user
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param claimURI             The name of the claim to be set.
+     * @param claimValue           The claim value to be set.
+     * @param profileName          The profile name of the user.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean setUserClaimValueV2(String userName, String claimURI, String claimValue,
                                        String profileName) throws UserStoreException {
@@ -448,12 +448,12 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Adds a single user claim value.
      *
-     * @param userName             the username of the user
-     * @param claimURI             the name of the claim
-     * @param claimValue           the claim value
-     * @param profileName          the profile name of the user
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param claimURI             The name of the claim.
+     * @param claimValue           The claim value.
+     * @param profileName          The profile name of the user.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean addUserClaimValueV2(String userName, String claimURI, String claimValue, String profileName)
             throws UserStoreException {
@@ -471,11 +471,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Updates the roles of a user.
      *
-     * @param userName             the username of the user
-     * @param deletedRoles         the roles to be removed from the user
-     * @param newRoles             the roles to be added to the user
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param userName             The username of the user.
+     * @param deletedRoles         The roles to be removed from the user.
+     * @param newRoles             The roles to be added to the user.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean updateRoleListOfUserV2(String userName, String[] deletedRoles, String[] newRoles)
             throws UserStoreException {
@@ -491,10 +491,10 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Updates the name of a role.
      *
-     * @param roleName             the name of the role to be updated
-     * @param newRoleName          the new name of the role
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param roleName             The name of the role to be updated.
+     * @param newRoleName          The new name of the role.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean updateRoleNameV2(String roleName, String newRoleName) throws UserStoreException {
 
@@ -510,11 +510,11 @@ public class UserStoreManagerService extends AbstractAdmin {
     /**
      * Updates the users assigned to a role.
      *
-     * @param roleName             the name of the role
-     * @param deletedUsers         the users to be removed from the role
-     * @param newUsers             the users to be added to the role
-     * @return                     true if the operation completes successfully
-     * @throws UserStoreException  if an error occurs during the operation
+     * @param roleName             The name of the role.
+     * @param deletedUsers         The users to be removed from the role.
+     * @param newUsers             The users to be added to the role.
+     * @return                     True if the operation completes successfully.
+     * @throws UserStoreException  If an error occurs during the operation.
      */
     public boolean updateUserListOfRoleV2(String roleName, String[] deletedUsers, String[] newUsers)
             throws UserStoreException {

--- a/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/UserStoreManagerService.java
+++ b/components/org.wso2.carbon.um.ws.service/src/main/java/org/wso2/carbon/um/ws/service/UserStoreManagerService.java
@@ -58,11 +58,46 @@ public class UserStoreManagerService extends AbstractAdmin {
                 convertClaimValueToMap(claims), profileName, requirePasswordChange);
     }
 
+    /**
+     * Adds a new user.
+     *
+     * @param userName              the username of the user
+     * @param credential            the credential/password of the user
+     * @param roleList              the roles to be assigned to the user
+     * @param claims                the properties of the user
+     * @param profileName           the profile name for the user
+     * @param requirePasswordChange whether to require a password change
+     * @return                      true if the operation completes successfully
+     * @throws UserStoreException   if an error occurs during the operation
+     */
+    public boolean addUserV2(String userName, String credential, String[] roleList, ClaimValue[] claims,
+                             String profileName, boolean requirePasswordChange) throws UserStoreException {
+
+        addUser(userName, credential, roleList, claims, profileName, requirePasswordChange);
+        return Boolean.TRUE;
+    }
+
     public void setUserClaimValues(String userName, ClaimValue[] claims, String profileName)
             throws UserStoreException {
         getUserStoreManager().setUserClaimValues(userName, convertClaimValueToMap(claims),
                 profileName);
 
+    }
+
+    /**
+     * Sets multiple user claim values.
+     *
+     * @param userName             the username of the user
+     * @param claims               the claims to be set
+     * @param profileName          the profile name of the user
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean setUserClaimValuesV2(String userName, ClaimValue[] claims, String profileName)
+            throws UserStoreException {
+
+        setUserClaimValues(userName, claims, profileName);
+        return Boolean.TRUE;
     }
 
     public void addUserClaimValues(String userName, ClaimValue[] claims, String profileName)
@@ -111,6 +146,22 @@ public class UserStoreManagerService extends AbstractAdmin {
         }
     }
 
+    /**
+     * Adds multiple user claim values.
+     *
+     * @param userName             the username of the user
+     * @param claims               the claims to be added
+     * @param profileName          the profile name of the user
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean addUserClaimValuesV2(String userName, ClaimValue[] claims, String profileName)
+            throws UserStoreException {
+
+        addUserClaimValues(userName, claims, profileName);
+        return Boolean.TRUE;
+    }
+
     public ClaimValue[] getUserClaimValuesForClaims(String userName, String[] claims,
                                                     String profileName) throws UserStoreException {
         return convertMapToClaimValue(getUserStoreManager().getUserClaimValues(userName, claims,
@@ -124,6 +175,22 @@ public class UserStoreManagerService extends AbstractAdmin {
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             throw (UserStoreException) e;
         }
+    }
+
+    /**
+     * Adds a new role.
+     *
+     * @param roleName             the name of the role to be added
+     * @param userList             the users to be assigned the added role
+     * @param permissions          the permissions of the role
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean addRoleV2(String roleName, String[] userList, PermissionDTO[] permissions)
+            throws UserStoreException {
+
+        addRole(roleName, userList, permissions);
+        return Boolean.TRUE;
     }
 
     public ClaimDTO[] getUserClaimValues(String userName, String profileName)
@@ -142,9 +209,40 @@ public class UserStoreManagerService extends AbstractAdmin {
 
     }
 
+    /**
+     * Updates a user's credential/password.
+     *
+     * @param userName             the username of the user
+     * @param newCredential        the new credential to be set
+     * @param oldCredential        the old credential to be changed
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean updateCredentialV2(String userName, String newCredential, String oldCredential)
+            throws UserStoreException {
+
+        updateCredential(userName, newCredential, oldCredential);
+        return Boolean.TRUE;
+    }
+
     public void updateCredentialByAdmin(String userName, String newCredential)
             throws UserStoreException {
         getUserStoreManager().updateCredentialByAdmin(userName, newCredential);
+    }
+
+    /**
+     * Updates a user's credential/password as an admin.
+     *
+     * @param userName             the username of the user
+     * @param newCredential        the new credential to be set
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean updateCredentialByAdminV2(String userName, String newCredential)
+            throws UserStoreException {
+
+        updateCredentialByAdmin(userName, newCredential);
+        return Boolean.TRUE;
     }
 
     public long getPasswordExpirationTime(String username) throws UserStoreException {
@@ -160,9 +258,35 @@ public class UserStoreManagerService extends AbstractAdmin {
 
     }
 
+    /**
+     * Deletes a role.
+     *
+     * @param roleName             the name of the role to be deleted
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean deleteRoleV2(String roleName) throws UserStoreException {
+
+        deleteRole(roleName);
+        return Boolean.TRUE;
+    }
+
     public void deleteUser(String userName) throws UserStoreException {
         getUserStoreManager().deleteUser(userName);
 
+    }
+
+    /**
+     * Deletes a user.
+     *
+     * @param userName             the name of the user to be deleted
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean deleteUserV2(String userName) throws UserStoreException {
+
+        deleteUser(userName);
+        return Boolean.TRUE;
     }
 
     public void deleteUserClaimValue(String userName, String claimURI, String profileName)
@@ -171,10 +295,42 @@ public class UserStoreManagerService extends AbstractAdmin {
 
     }
 
+    /**
+     * Deletes a single user claim value.
+     *
+     * @param userName             the username of the user
+     * @param claimURI             the name of the claim
+     * @param profileName          the profile name of the user
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean deleteUserClaimValueV2(String userName, String claimURI, String profileName)
+            throws UserStoreException {
+
+        deleteUserClaimValue(userName, claimURI, profileName);
+        return Boolean.TRUE;
+    }
+
     public void deleteUserClaimValues(String userName, String[] claims, String profileName)
             throws UserStoreException {
         getUserStoreManager().deleteUserClaimValues(userName, claims, profileName);
 
+    }
+
+    /**
+     * Deletes multiple user claim values.
+     *
+     * @param userName             the username of the user
+     * @param claims               the names of the claims
+     * @param profileName          the profile name of the user
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean deleteUserClaimValuesV2(String userName, String[] claims, String profileName)
+            throws UserStoreException {
+
+        deleteUserClaimValues(userName, claims, profileName);
+        return Boolean.TRUE;
     }
 
     public String[] getAllProfileNames() throws UserStoreException {
@@ -258,6 +414,22 @@ public class UserStoreManagerService extends AbstractAdmin {
 
     }
 
+    /**
+     * Sets a single user claim value.
+     *
+     * @param userName             the username of the user
+     * @param claimURI             the name of the claim to be set
+     * @param claimValue           the claim value to be set
+     * @param profileName          the profile name of the user
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean setUserClaimValueV2(String userName, String claimURI, String claimValue,
+                                       String profileName) throws UserStoreException {
+
+        setUserClaimValue(userName, claimURI, claimValue, profileName);
+        return Boolean.TRUE;
+    }
 
     public void addUserClaimValue(String userName, String claimURI, String claimValue, String profileName)
             throws UserStoreException {
@@ -273,20 +445,82 @@ public class UserStoreManagerService extends AbstractAdmin {
         getUserStoreManager().setUserClaimValue(userName, claimURI, claimValue, profileName);
     }
 
+    /**
+     * Adds a single user claim value.
+     *
+     * @param userName             the username of the user
+     * @param claimURI             the name of the claim
+     * @param claimValue           the claim value
+     * @param profileName          the profile name of the user
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean addUserClaimValueV2(String userName, String claimURI, String claimValue, String profileName)
+            throws UserStoreException {
+
+        addUserClaimValue(userName, claimURI, claimValue, profileName);
+        return Boolean.TRUE;
+    }
+
     public void updateRoleListOfUser(String userName, String[] deletedRoles, String[] newRoles)
             throws UserStoreException {
         getUserStoreManager().updateRoleListOfUser(userName, deletedRoles, newRoles);
 
     }
 
+    /**
+     * Updates the roles of a user.
+     *
+     * @param userName             the username of the user
+     * @param deletedRoles         the roles to be removed from the user
+     * @param newRoles             the roles to be added to the user
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean updateRoleListOfUserV2(String userName, String[] deletedRoles, String[] newRoles)
+            throws UserStoreException {
+
+        updateRoleListOfUser(userName, deletedRoles, newRoles);
+        return Boolean.TRUE;
+    }
+
     public void updateRoleName(String roleName, String newRoleName) throws UserStoreException {
         getUserStoreManager().updateRoleName(roleName, newRoleName);
     }
 
+    /**
+     * Updates the name of a role.
+     *
+     * @param roleName             the name of the role to be updated
+     * @param newRoleName          the new name of the role
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean updateRoleNameV2(String roleName, String newRoleName) throws UserStoreException {
+
+        updateRoleName(roleName, newRoleName);
+        return Boolean.TRUE;
+    }
 
     public void updateUserListOfRole(String roleName, String[] deletedUsers, String[] newUsers)
             throws UserStoreException {
         getUserStoreManager().updateUserListOfRole(roleName, deletedUsers, newUsers);
+    }
+
+    /**
+     * Updates the users assigned to a role.
+     *
+     * @param roleName             the name of the role
+     * @param deletedUsers         the users to be removed from the role
+     * @param newUsers             the users to be added to the role
+     * @return                     true if the operation completes successfully
+     * @throws UserStoreException  if an error occurs during the operation
+     */
+    public boolean updateUserListOfRoleV2(String roleName, String[] deletedUsers, String[] newUsers)
+            throws UserStoreException {
+
+        updateUserListOfRole(roleName, deletedUsers, newUsers);
+        return Boolean.TRUE;
     }
 
     private UserStoreManager getUserStoreManager() throws UserStoreException {

--- a/components/org.wso2.carbon.um.ws.service/src/main/resources/META-INF/services.xml
+++ b/components/org.wso2.carbon.um.ws.service/src/main/resources/META-INF/services.xml
@@ -43,11 +43,23 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="addRoleV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/rolemgt/create
+            </parameter>
+        </operation>
+
         <operation name="addUser" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/usermgt/create
             </parameter>
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        </operation>
+
+        <operation name="addUserV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/create
+            </parameter>
         </operation>
 
         <operation name="addUserClaimValue" mep="http://www.w3.org/ns/wsdl/in-only">
@@ -57,11 +69,23 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="addUserClaimValueV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/update
+            </parameter>
+        </operation>
+
         <operation name="addUserClaimValues" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/usermgt/update
             </parameter>
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        </operation>
+
+        <operation name="addUserClaimValuesV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/update
+            </parameter>
         </operation>
 
         <operation name="authenticate">
@@ -77,11 +101,23 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="deleteRoleV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/rolemgt/delete
+            </parameter>
+        </operation>
+
         <operation name="deleteUser" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/usermgt/delete
             </parameter>
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        </operation>
+
+        <operation name="deleteUserV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/delete
+            </parameter>
         </operation>
 
         <operation name="deleteUserClaimValue" mep="http://www.w3.org/ns/wsdl/in-only">
@@ -91,11 +127,23 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="deleteUserClaimValueV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/delete
+            </parameter>
+        </operation>
+
         <operation name="deleteUserClaimValues" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/usermgt/delete
             </parameter>
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        </operation>
+
+        <operation name="deleteUserClaimValuesV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/delete
+            </parameter>
         </operation>
 
         <operation name="getAllProfileNames">
@@ -213,11 +261,23 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="setUserClaimValueV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/update
+            </parameter>
+        </operation>
+
         <operation name="setUserClaimValues" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/usermgt/update
             </parameter>
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        </operation>
+
+        <operation name="setUserClaimValuesV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/update
+            </parameter>
         </operation>
 
         <operation name="updateCredential" mep="http://www.w3.org/ns/wsdl/in-only">
@@ -227,11 +287,23 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="updateCredentialV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/update
+            </parameter>
+        </operation>
+
         <operation name="updateCredentialByAdmin" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/usermgt/update
             </parameter>
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        </operation>
+
+        <operation name="updateCredentialByAdminV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/update
+            </parameter>
         </operation>
 
         <operation name="updateRoleListOfUser" mep="http://www.w3.org/ns/wsdl/in-only">
@@ -241,6 +313,12 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="updateRoleListOfUserV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/usermgt/update
+            </parameter>
+        </operation>
+
         <operation name="updateRoleName" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/rolemgt/update
@@ -248,11 +326,23 @@
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
         </operation>
 
+        <operation name="updateRoleNameV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/rolemgt/update
+            </parameter>
+        </operation>
+
         <operation name="updateUserListOfRole" mep="http://www.w3.org/ns/wsdl/in-only">
             <parameter name="AuthorizationAction"
                        locked="true">/permission/admin/manage/identity/rolemgt/update
             </parameter>
             <messageReceiver class="org.apache.axis2.rpc.receivers.RPCInOnlyMessageReceiver"/>
+        </operation>
+
+        <operation name="updateUserListOfRoleV2">
+            <parameter name="AuthorizationAction"
+                       locked="true">/permission/admin/manage/identity/rolemgt/update
+            </parameter>
         </operation>
     </service>
 


### PR DESCRIPTION
### Proposed changes in this pull request

Adds two-way operations to the RemoteUserStoreManagerService SOAP API which return non-void responses and error responses when the operations fail.

## Related PRs

- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/537

## Related Issues

- https://github.com/wso2/product-is/issues/19114